### PR TITLE
Wait for database if run on slow machine

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -3,6 +3,12 @@ set -e -o pipefail
 # First build containers, compile messages, collect static files (copy them to static_root) and migrate database
 export CURRENT_UID=$(id -u):$(id -g)
 docker-compose -f docker-compose.dev.yml -f docker-compose.prod.yml up -d --build
+echo "Waiting for database"
+while [ $(docker exec match4everything_database_1 psql | grep "Is the server running locally and accepting" | wc -l ) -ge 1 ] || \
+	[ $(docker exec match4everything_database_1 psql | grep "psql: error: could not connect to server: FATAL:  the database system is starting up" | wc -l ) -ge 1 ] ; do
+    sleep 1
+done
+echo "Server started for setup"
 docker exec backend python3 manage.py migrate
 docker exec --env PYTHONPATH="/match4everyone-backend:$PYTHONPATH" backend django-admin makemessages --no-location --ignore 00_old_m4h_matching_code
 docker exec --env PYTHONPATH="/match4everyone-backend:$PYTHONPATH" backend django-admin compilemessages
@@ -12,3 +18,4 @@ docker exec backend python3 manage.py check
 # Restart container AFTER static files have been collected
 docker-compose -f docker-compose.dev.yml -f docker-compose.prod.yml down
 docker-compose -f docker-compose.dev.yml -f docker-compose.prod.yml up -d
+echo "Server is ready for you"

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,11 +3,6 @@ set -e -o pipefail
 # First build containers, compile messages, collect static files (copy them to static_root) and migrate database
 export CURRENT_UID=$(id -u):$(id -g)
 docker-compose -f docker-compose.dev.yml -f docker-compose.prod.yml up -d --build
-echo "Waiting for database"
-while [ $(docker exec match4everything_database_1 psql | grep "Is the server running locally and accepting" | wc -l ) -ge 1 ] || \
-	[ $(docker exec match4everything_database_1 psql | grep "psql: error: could not connect to server: FATAL:  the database system is starting up" | wc -l ) -ge 1 ] ; do
-    sleep 1
-done
 echo "Server started for setup"
 docker exec backend python3 manage.py migrate
 docker exec --env PYTHONPATH="/match4everyone-backend:$PYTHONPATH" backend django-admin makemessages --no-location --ignore 00_old_m4h_matching_code

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,7 +15,7 @@ services:
     environment:
      - DJANGO_SETTINGS_MODULE=match4everyone.settings.production
     user: ${CURRENT_UID:-0}
-    command: bash -c 'while !</dev/tcp/database/5432 &> /dev/null; do echo "Waiting for database..."; sleep 1; done; gunicorn -c /match4everyone-backend/gunicorn.conf.py match4everyone.wsgi'
+    command: bash -c 'while ! (< /dev/tcp/database/5432) &> /dev/null; do sleep 1; done; gunicorn -c /match4everyone-backend/gunicorn.conf.py match4everyone.wsgi'
     depends_on:
       - database
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,7 +15,7 @@ services:
     environment:
      - DJANGO_SETTINGS_MODULE=match4everyone.settings.production
     user: ${CURRENT_UID:-0}
-    command: gunicorn -c /match4everyone-backend/gunicorn.conf.py match4everyone.wsgi
+    command: bash -c 'while !</dev/tcp/database/5432; do sleep 1; done; gunicorn -c /match4everyone-backend/gunicorn.conf.py match4everyone.wsgi'
     depends_on:
       - database
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,7 +15,7 @@ services:
     environment:
      - DJANGO_SETTINGS_MODULE=match4everyone.settings.production
     user: ${CURRENT_UID:-0}
-    command: bash -c 'while !</dev/tcp/database/5432; do sleep 1; done; gunicorn -c /match4everyone-backend/gunicorn.conf.py match4everyone.wsgi'
+    command: bash -c 'while !</dev/tcp/database/5432 &> /dev/null; do echo "Waiting for database..."; sleep 1; done; gunicorn -c /match4everyone-backend/gunicorn.conf.py match4everyone.wsgi'
     depends_on:
       - database
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,7 +15,7 @@ services:
     environment:
      - DJANGO_SETTINGS_MODULE=match4everyone.settings.production
     user: ${CURRENT_UID:-0}
-    command: bash -c 'while ! (< /dev/tcp/database/5432) &> /dev/null; do sleep 1; done; gunicorn -c /match4everyone-backend/gunicorn.conf.py match4everyone.wsgi'
+    command: bash -c 'while ! (< /dev/tcp/database/5432) &> /dev/null; do echo "Waiting for database..."; sleep 1; done; gunicorn -c /match4everyone-backend/gunicorn.conf.py match4everyone.wsgi'
     depends_on:
       - database
 


### PR DESCRIPTION
Depends on #7 

@kevihiiin It currently prints the error from the docker command we use to check the status. I tried to prevent the output but wasn't very successful. Do you have an idea for this?