### PR TITLE
Use user 'postgres' for postgres container

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,6 +32,7 @@ services:
      - database.prod.env
     expose:
      -  5432
+    user: postgres
     networks:
      - network
     command: postgres -c config_file=/etc/postgresql.conf


### PR DESCRIPTION
Seems to work but currently not really testable with https://github.com/match4everyone/match4everything/issues/9