### PR TITLE
[Discussion] How to handle view restrictions?

### DIFF
--- a/backend/apps/matching/admin.py
+++ b/backend/apps/matching/admin.py
@@ -1,7 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import user_passes_test
-from django.http import Http404
 
 from .models import User
 
@@ -23,22 +22,5 @@ def participant_required(function=None, redirect_field_name=REDIRECT_FIELD_NAME,
     return actual_decorator
 
 
-def matching_participant_required(function=None):
-    """
-    Check that participant matches url.
-
-    Decorator for views that checks that the user is logged in,
-    and that the user matches to the /<p_type:p_type> url
-    """
-
-    def actual_decorator(function):
-        def new_func(request, p_type, *args, **kwargs):
-            if (request.user.is_A and p_type == "A") or (request.user.is_B and p_type == "B"):
-                return function(request, p_type, *args, **kwargs)
-            raise Http404
-
-        return new_func
-
-    if function:
-        return actual_decorator(function)
-    return actual_decorator
+def participant_check(user):
+    return user.is_participant

--- a/backend/apps/matching/urls.py
+++ b/backend/apps/matching/urls.py
@@ -1,7 +1,10 @@
 from django.conf import settings
 from django.contrib.auth import views as auth_views
+from django.contrib.auth.decorators import login_required, user_passes_test
 from django.urls import include, path, register_converter
 from django.views.generic.base import TemplateView
+
+from apps.matching.admin import participant_check
 
 from . import views
 from .src import converters
@@ -15,10 +18,14 @@ urlpatterns = [
     ####################################
     path("<p:p_type>/signup", views.ParticipantSignup.as_view(), name="signup"),
     path("profile_redirect", views.ProfileDashboardRedirect.as_view(), name="profile_redirect"),
-    path("<p:p_type>/profile", views.ParticipantDashboard.as_view(), name="profile"),
+    path(
+        "<p:p_type>/profile",
+        login_required(user_passes_test(participant_check)(views.ParticipantDashboard.as_view())),
+        name="profile",
+    ),
     path(
         "<p:p_type>/info/<str:uuid>/edit/",
-        views.ParticipantInfoUpdateView.as_view(),
+        login_required(views.ParticipantInfoUpdateView.as_view()),
         name="info-edit",
     ),
     path(

--- a/backend/apps/matching/views/participant_dashboard.py
+++ b/backend/apps/matching/views/participant_dashboard.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.contrib.auth.mixins import UserPassesTestMixin
 from django.views.generic.base import TemplateView
 
 from apps.matching.admin import participant_check
@@ -12,7 +12,7 @@ View the dashboard of a participant
 """
 
 
-class ParticipantDashboard(TemplateView, LoginRequiredMixin, UserPassesTestMixin):
+class ParticipantDashboard(TemplateView, UserPassesTestMixin):
     def test_func(self):
         return participant_check(self.request.user)
 

--- a/backend/apps/matching/views/participant_dashboard.py
+++ b/backend/apps/matching/views/participant_dashboard.py
@@ -1,10 +1,9 @@
 import logging
 
-from django.contrib.auth.decorators import login_required
-from django.utils.decorators import method_decorator
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.views.generic.base import TemplateView
 
-from apps.matching.admin import matching_participant_required
+from apps.matching.admin import participant_check
 
 logger = logging.getLogger(__name__)
 
@@ -13,8 +12,10 @@ View the dashboard of a participant
 """
 
 
-@method_decorator([login_required, matching_participant_required], name="dispatch")
-class ParticipantDashboard(TemplateView):
+class ParticipantDashboard(TemplateView, LoginRequiredMixin, UserPassesTestMixin):
+    def test_func(self):
+        return participant_check(self.request.user)
+
     template_name = "participant/participant_dashboard.html"
 
     def get_context_data(self, *args, **kwargs):

--- a/backend/apps/matching/views/participant_profile_edit.py
+++ b/backend/apps/matching/views/participant_profile_edit.py
@@ -1,18 +1,19 @@
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.urls import reverse
-from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic.edit import UpdateView
 
-from apps.matching.admin import matching_participant_required
+from apps.matching.admin import participant_check
 from apps.matching.forms import ParticipantEditInfoForm
 from apps.matching.models import ParticipantInfo
 
 
-@method_decorator([login_required, matching_participant_required], name="dispatch")
-class ParticipantInfoUpdateView(UpdateView):
+class ParticipantInfoUpdateView(UpdateView, LoginRequiredMixin, UserPassesTestMixin):
     """Updates the information of either participant."""
+
+    def test_func(self):
+        return participant_check(self.request.user)
 
     template_name = "participant/participant_info_edit_form.html"
     slug_url_kwarg = "uuid"

--- a/backend/apps/matching/views/participant_profile_edit.py
+++ b/backend/apps/matching/views/participant_profile_edit.py
@@ -1,19 +1,14 @@
 from django.contrib import messages
-from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic.edit import UpdateView
 
-from apps.matching.admin import participant_check
 from apps.matching.forms import ParticipantEditInfoForm
 from apps.matching.models import ParticipantInfo
 
 
-class ParticipantInfoUpdateView(UpdateView, LoginRequiredMixin, UserPassesTestMixin):
+class ParticipantInfoUpdateView(UpdateView):
     """Updates the information of either participant."""
-
-    def test_func(self):
-        return participant_check(self.request.user)
 
     template_name = "participant/participant_info_edit_form.html"
     slug_url_kwarg = "uuid"


### PR DESCRIPTION
This PR should be more a discussion than an immediate code change.

There exist many options for handling restrictions on who can access a view/page in django. A (possibly incomplete) list is:

## Function based views
- use **custom decorators**
- use **django decorators** (`@login_required`, `@has_permission('my_permission')`, `@user_passes_test(my_custom_check)`)

## Class based views
- use **method decorators** on class to pass custom or django decorators to specific method in class _(This is the case on staging atm)_ 
```python
@method_decorator(my_check_method, name='dispatch')
class ParticipantDashboard(TemplateView):
```
This a somewhat antiquated version i think and stems from when Django had no Mixins. The verbose version of this (which is boilerplate, but is more understandable I think) is:
```python
class ParticipantDashboard(TemplateView):

        @method_decorator(login_required)
        @method_decorator(is_participant)
        def dispatch(self, *args, **kwargs):
            return super(ParticipantDashboard, self).dispatch(*args, **kwargs)
```
- Use **Mixins** and include the check method in the class _(This is the case in f8c818a)_ 
```python
ParticipantDashboard(TemplateView, LoginRequiredMixin, UserPassesTestMixin):
    def test_func(self):
        return participant_check(self.request.user)
```

## Use urls.py regardless of view type
- add **decorator methods** directly around view constructor **in urls.py** _(This is the case in 7a3e2e1c)_
https://github.com/match4everyone/match4everything/blob/7a3e2e1c7056834584c476762431569905462b3c/backend/apps/matching/urls.py#L23


Given all these options and the possibility to use all of them, I think we should decide for one or two ways to keep things consistent. Discussion opened :grin: 