### PR TITLE
Remove imperative docstring checking

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,7 +3,7 @@ max-line-length = 100
 # When adding a new category, make sure to include the lib in .pre-commit-config.yaml under
 # flake8>additional_dependencies, otherwise it will not be installed to pre-commits private env
 select=C,E,F,W,B,I,A,D,T,G
-ignore = E203, E501, W503, E231, D1, T002, G202
+ignore = E203, E501, W503, E231, D1, T002, G202, D401
 application-package-names = apps, match4everyone
 import-order-style = appnexus
 # maybe switch back to google once all code is in a single app


### PR DESCRIPTION
As seen in: https://github.com/PyCQA/pydocstyle/issues/68,
checking if a docstring is in imperative is a complicated and delicate problem.
I also believe this adds no value to our project and instead just stops us from being productive.