### PR TITLE
Allow access to /admin again

### DIFF
--- a/tools/nginx-sample-site
+++ b/tools/nginx-sample-site
@@ -46,11 +46,6 @@ server {
             #internal;
         }
 
-        location /admin {
-                allow 127.0.0.1;
-                deny all;
-        }
-
         location / {
                 # First attempt to serve request as file, then
                 # as directory, then fall back to displaying a 404


### PR DESCRIPTION
All users of django-cms, also people not accustomed to ssh, have to access the admin page.