### PR TITLE
Specify correct master file for read the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,9 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
+# Use index.rst instead of contents.rst as in https://github.com/readthedocs/readthedocs.org/issues/2569#issuecomment-485117471
+master_doc = "index"
+
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Error was
```python
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/match4everything/envs/latest/lib/python3.7/site-packages/sphinx/cmd/build.py", line 304, in build_main
    app.build(args.force_all, filenames)
  File "/home/docs/checkouts/readthedocs.org/user_builds/match4everything/envs/latest/lib/python3.7/site-packages/sphinx/application.py", line 341, in build
    self.builder.build_update()
  File "/home/docs/checkouts/readthedocs.org/user_builds/match4everything/envs/latest/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 347, in build_update
    len(to_build))
  File "/home/docs/checkouts/readthedocs.org/user_builds/match4everything/envs/latest/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 360, in build
    updated_docnames = set(self.read())
  File "/home/docs/checkouts/readthedocs.org/user_builds/match4everything/envs/latest/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 472, in read
    self.env.doc2path(self.config.master_doc))
sphinx.errors.SphinxError: master file /home/docs/checkouts/readthedocs.org/user_builds/match4everything/checkouts/latest/docs/contents.rst not found
```