### PR TITLE
Use BASE_URL instead of hardcoded url for facebook open graph

### DIFF
--- a/backend/match4everyone/settings/common.py
+++ b/backend/match4everyone/settings/common.py
@@ -90,6 +90,7 @@ TEMPLATES = [
                 "sekizai.context_processors.sekizai",
                 "cms.context_processors.cms_settings",
                 "django.template.context_processors.i18n",
+                "django_settings_export.settings_export",
             ],
         },
     },
@@ -289,3 +290,10 @@ IS_FORK = False
 
 if IS_TRAVIS and os.environ["TRAVIS_PULL_REQUEST_SLUG"] not in ["match4everyone/match4everything"]:
     IS_FORK = True
+
+# This is only used in the META tags for facebook's og
+BASE_URL = "https://match4everyone.de"
+
+SETTINGS_EXPORT = [
+    "BASE_URL",
+]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ django-filter==2.2.0
 django-formtools==2.2
 django-sekizai==1.1.0
 django-sendgrid-v5==0.8.1
+django-settings-export==1.2.1
 django-tables2==2.3.1
 django-treebeard==4.3.1
 django-webpack-loader==0.7.0

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -31,10 +31,10 @@
     <meta name="theme-color" content="#ffffff">
 
     <meta property="og:type" content="website">
-    <meta property="og:image" content="https://match4everyone.de{% static 'img/share_icons/facebook-share.jpg' %}">
+    <meta property="og:image" content="{{ settings.BASE_URL }}{% static 'img/share_icons/facebook-share.jpg' %}">
     <meta property="og:image:secure_url"
-          content="https://match4everyone.de{% static 'img/share_icons/facebook-share.jpg' %}">
-    <meta name="twitter:image" content="https://match4everyone.de{% static 'img/share_icons/facebook-share.jpg' %}">
+          content="{{ settings.BASE_URL }}{% static 'img/share_icons/facebook-share.jpg' %}">
+    <meta name="twitter:image" content="{{ settings.BASE_URL }}{% static 'img/share_icons/facebook-share.jpg' %}">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <title>{% block title %} {% endblock %} | match4everyone </title>


### PR DESCRIPTION
I introduced `django-settings-export` to easily access config variables in the templates. What do you think about this?

Fixes #127