### PR TITLE
Route for filter type options

### DIFF
--- a/backend/apps/matching/configuration/participant.py
+++ b/backend/apps/matching/configuration/participant.py
@@ -27,3 +27,6 @@ class ParticipantConfig:
         names = self.get_model_field_names()
         filters = chain(*[p.get_filters() for p in self.properties])
         return zip(names, filters)
+
+    def to_filter_json(self):
+        return {"properties": list(filter(None, [p.to_filter_json() for p in self.properties]))}

--- a/backend/apps/matching/urls.py
+++ b/backend/apps/matching/urls.py
@@ -51,6 +51,11 @@ urlpatterns = [
         views.ParticipantInfoListAPI.as_view(),
         name="api_participant_list",
     ),
+    path(
+        "api/<p:p_type>/info/filter-options/",
+        views.view_FilterOptionsJSON,
+        name="api_filter_options",
+    ),
     path("<p:p_type>/", views.FilteredParticipantList.as_view(), name="participant_list",),
     path(
         "<p:p_type>/filter/create",

--- a/backend/apps/matching/views/__init__.py
+++ b/backend/apps/matching/views/__init__.py
@@ -1,6 +1,7 @@
 from .filter_edit import FilterUpdateView  # noqa
 from .filter_list import FilterListView  # noqa
 from .filtered_participants import FilteredParticipantList  # noqa
+from .filter_options import view_FilterOptionsJSON  # noqa
 from .mail_limits import IncreaseMailLimitView  # noqa
 from .map import map_JSON, map_view  # noqa
 from .participant_change_activation import ChangeActivationAskView, ChangeActivationRedirect  # noqa

--- a/backend/apps/matching/views/filter_options.py
+++ b/backend/apps/matching/views/filter_options.py
@@ -1,0 +1,15 @@
+from django.http import JsonResponse
+from django.shortcuts import Http404
+
+from match4everyone.configuration.A import A
+from match4everyone.configuration.B import B
+
+
+def view_FilterOptionsJSON(request, p_type):
+
+    if p_type == "A":
+        return JsonResponse(A().to_filter_json())
+    elif p_type == "B":
+        return JsonResponse(B().to_filter_json())
+
+    raise Http404


### PR DESCRIPTION
Depends on #173 

Introduce a route for json filter options:

`http://127.0.0.1:8000/matching/api/A/info/filter-options/`