### PR TITLE
Implement API rate limits

### DIFF
--- a/backend/apps/matching/utils/rest_framework/pagination.py
+++ b/backend/apps/matching/utils/rest_framework/pagination.py
@@ -1,0 +1,5 @@
+from rest_framework.pagination import LimitOffsetPagination
+
+
+class StrictLimitOffsetPagination(LimitOffsetPagination):
+    max_limit = 15

--- a/backend/apps/matching/utils/rest_framework/throttling.py
+++ b/backend/apps/matching/utils/rest_framework/throttling.py
@@ -1,0 +1,13 @@
+from rest_framework.throttling import UserRateThrottle
+
+
+class UserMinRateThrottle(UserRateThrottle):
+    scope = "user_min"
+
+
+class UserHRateThrottle(UserRateThrottle):
+    scope = "user_h"
+
+
+class UserDayRateThrottle(UserRateThrottle):
+    scope = "user_day"

--- a/backend/match4everyone/settings/common.py
+++ b/backend/match4everyone/settings/common.py
@@ -205,7 +205,7 @@ REST_FRAMEWORK = {
         "apps.matching.utils.rest_framework.throttling.UserHRateThrottle",
         "apps.matching.utils.rest_framework.throttling.UserDayRateThrottle",
     ],
-    "DEFAULT_THROTTLE_RATES": {"user_min": "5/min", "user_h": "100/h", "user_day": "100/day",},
+    "DEFAULT_THROTTLE_RATES": {"user_min": "15/min", "user_h": "100/h", "user_day": "100/day",},
 }
 
 

--- a/backend/match4everyone/settings/common.py
+++ b/backend/match4everyone/settings/common.py
@@ -197,7 +197,16 @@ MESSAGE_TAGS = {
     messages.ERROR: "alert-danger",
 }
 
-REST_FRAMEWORK = {"DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination"}
+REST_FRAMEWORK = {
+    "DEFAULT_PAGINATION_CLASS": "apps.matching.utils.rest_framework.pagination.StrictLimitOffsetPagination",
+    "PAGE_SIZE": 15,
+    "DEFAULT_THROTTLE_CLASSES": [
+        "apps.matching.utils.rest_framework.throttling.UserMinRateThrottle",
+        "apps.matching.utils.rest_framework.throttling.UserHRateThrottle",
+        "apps.matching.utils.rest_framework.throttling.UserDayRateThrottle",
+    ],
+    "DEFAULT_THROTTLE_RATES": {"user_min": "5/min", "user_h": "100/h", "user_day": "100/day",},
+}
 
 
 # Configure Logging for all environments


### PR DESCRIPTION
With this settings, a user is only allowed to retrieve 15*100=1500 users per day. @match4everyone/match4everyone Currently, this has to be changed in the `settings/common.py` and not like in `A.py` and `B.py`. Do we want to expose such general settings also in something like a `general.py` or should we just document that the user has to change that in `settings/common.py`?

Closes #177

Depends on #173