### PR TITLE
Alternate implementation of #175

### DIFF
--- a/backend/apps/matching/management/commands/createfakeusers.py
+++ b/backend/apps/matching/management/commands/createfakeusers.py
@@ -60,9 +60,9 @@ class Command(BaseCommand):
         if options["delete"]:
             self.delete_all_fakes()
         if options["add_{a}".format(a=A.url_name)] is not None:
-            self.add_fake("A", int(options["add_{a}".format(a=A.url_name)][0]))
+            self.add_fake(participant_type="A", n=int(options["add_{a}".format(a=A.url_name)][0]))
         if options["add_{b}".format(b=B.url_name)] is not None:
-            self.add_fake("B", int(options["add_{b}".format(b=B.url_name)][0]))
+            self.add_fake(participant_type="B", n=int(options["add_{b}".format(b=B.url_name)][0]))
 
     def delete_all_fakes(self):
         qs = User.objects.filter(email__contains=FAKE_MAIL)
@@ -94,8 +94,8 @@ class Command(BaseCommand):
             m = participant_type + new_mail(i + n_users)
             u = User.new(
                 email=m,
-                is_A=participant_type == A.url_name,
-                is_B=participant_type == B.url_name,
+                is_A=participant_type == "A",
+                is_B=participant_type == "B",
                 is_participant=True,
                 validated_email=True,
                 date_joined=datetime.now() - timedelta(days=np.random.randint(0, 30)),

--- a/backend/apps/matching/migrations/0002_permission_group_creation.py
+++ b/backend/apps/matching/migrations/0002_permission_group_creation.py
@@ -81,6 +81,8 @@ class Migration(migrations.Migration):
 
         group_is_a, created = Group.objects.get_or_create(name="is_a")
         group_is_b, created = Group.objects.get_or_create(name="is_b")
+        group_can_view_a, created = Group.objects.get_or_create(name="can_view_a")
+        group_can_view_b, created = Group.objects.get_or_create(name="can_view_b")
         group_is_a_approved, created = Group.objects.get_or_create(name="approved_a")
         group_is_b_approved, created = Group.objects.get_or_create(name="approved_b")
         group_perm_user_stats, created = Group.objects.get_or_create(name="perm_user_stats")
@@ -106,12 +108,20 @@ class Migration(migrations.Migration):
         can_send_newsletter = Permission.objects.get(codename=NewPermissions.can_send_newsletter)
         group_perm_send_newsletter.permissions.add(can_send_newsletter)
 
+        can_view_a = Permission.objects.get(codename="matching.view_participanta")
+        group_can_view_a.permissions.add(can_view_a)
+
+        can_view_b = Permission.objects.get(codename="matching.view_participantb")
+        group_can_view_b.permissions.add(can_view_b)
+
     def delete_groups(apps, schema_editor):
         Group = apps.get_model("auth", "Group")
 
         group_list = [
             "is_a",
             "is_b",
+            "can_view_a",
+            "can_view_b",
             "approved_a",
             "approved_b",
             "perm_user_stats",

--- a/backend/apps/matching/models/user.py
+++ b/backend/apps/matching/models/user.py
@@ -1,9 +1,12 @@
 import logging
 
-from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.models import AbstractUser, Group
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+
+from match4everyone.configuration.A import A
+from match4everyone.configuration.B import B
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +38,25 @@ class User(AbstractUser):
             user.set_password(pwd)
         else:
             user.set_password(email)
+
+        group_is_a = Group.objects.get(name="is_a")
+        group_is_b = Group.objects.get(name="is_b")
+        group_can_view_a = Group.objects.get(name="can_view_a")
+        group_can_view_b = Group.objects.get(name="can_view_b")
+
+        if kwargs["is_A"]:
+            user.groups.add(group_is_a)
+            if B.profile_visible_for_A:
+                user.groups.add(group_can_view_b)
+            if A.profile_visible_for_other_A:
+                user.groups.add(group_can_view_a)
+        elif kwargs["B"]:
+            user.groups.add(group_is_b)
+            if A.profile_visible_for_B:
+                user.groups.add(group_can_view_a)
+            if B.profile_visible_for_other_B:
+                user.groups.add(group_can_view_b)
+
         user.save()
         return user
 

--- a/backend/match4everyone/configuration/A.py
+++ b/backend/match4everyone/configuration/A.py
@@ -12,6 +12,8 @@ class AConfig(ParticipantConfig):
     # permissions = [
     #    NewPermissions.can_contact_type_b,
     # ]
+    profile_visible_for_B = True
+    profile_visible_for_other_A = False
 
     properties = [
         m4e.PropertyGroup(

--- a/backend/match4everyone/configuration/B.py
+++ b/backend/match4everyone/configuration/B.py
@@ -13,6 +13,9 @@ class BConfig(ParticipantConfig):
     #    NewPermissions.can_contact_type_a_if_approved,
     # ]
 
+    profile_visible_for_A = True
+    profile_visible_for_other_B = False
+
     properties = [
         m4e.TextProperty(
             name="name",


### PR DESCRIPTION
This is an alternative to #175, which has all the logic moved to user creation, thus only needing two built-in django permissions which can easily be checked for.

Given that the profile_view-view is probably the only time this is used and we have to implement the logic in dispatch for #120, I think not going with decorators here is a fine solution.  