### PR TITLE
Enable favicon template in devMode

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -141,7 +141,13 @@ module.exports = {
         })],
     },
     plugins: [
-        new CleanWebpackPlugin(),
+        new CleanWebpackPlugin({
+            verbose: true,
+            cleanOnceBeforeBuildPatterns: [
+                '**/*',                 // Remove all files
+                '!favicon'              // Except for favicon stuff, that is expensive to build and only built on production run
+            ],
+        }),
         new BundleTracker({
             path: path.resolve(__dirname, 'dist'),
             filename: 'webpack-stats.json',
@@ -157,6 +163,8 @@ module.exports = {
             // Prefix path for generated assets in generated html
             prefix: 'favicon',
             inject: false,
+            devMode: 'webapp',
+            mode: 'webapp',
             favicons: {
                 appName: 'match4everyone',
                 appShortName: 'm4e',


### PR DESCRIPTION
The favicon template introduced in #204  is only generated in production builds. Running the webpack build process in development mode will not create the needed files. This PR enables building the files in devMode as well.

The cleanUp Process (deletes dist/* on each build) is also modified not to delete the favicon files. This allows for the cache option to work and keeps the build process fast in devMode (except for the first one)