### PR TITLE
Set black to specific version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         # args: [--filter-files]
 # use black or autopep8 to automatically format files to pep8
 -   repo: https://github.com/psf/black
-    rev: stable
+    rev: "19.10b0"
     hooks:
     -   id: black
         args: [--line-length=100]


### PR DESCRIPTION
The new version ([20.8b1](https://github.com/psf/black/releases/tag/20.8b1)) does not respect our line length.